### PR TITLE
Add repository node to get better linking on npmjs.org.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,9 @@
   },
   "scripts": {
     "build": "./node_modules/.bin/cake build"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paulyoung/fontello-cli.git"
   }
 }


### PR DESCRIPTION
Previously a user had to do a manual search on github to find the repo by username "paulyoung" and "fontello*".
