### PR TITLE
Fix directory check error, fix printing error

### DIFF
--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -13,7 +13,7 @@ dirIsValid = (path) ->
     return false unless fs.statSync(path).isDirectory()
   catch e
     mkdirp.sync path
-    return true
+  return true
 
 
 config = 'config.json'
@@ -37,11 +37,11 @@ program
     #
     if program.css and program.font
       unless dirIsValid program.css
-        print '--css path provided is not a directory.\n'.red
+        console.log '--css path provided is not a directory.\n'.red
         process.exit 1
 
       unless dirIsValid program.font
-        print '--font path provided is not a directory.\n'.red
+        console.log '--font path provided is not a directory.\n'.red
         process.exit 1
 
     fontello.install


### PR DESCRIPTION
`dirIsValid` returned `undefined` if directory exists and this caused "--css path provided is not a directory." message to be printed. Also `print()` function was not defined. Used `console.log` instead.
