### PR TITLE
Add missing .json extension to --config flag

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -31,7 +31,7 @@
 
   config = 'config.json';
 
-  program.version(pjson.version).usage('[command] [options]').option('--config [path]', 'path to fontello config. defaults to ./config').option('--css [path]', 'path to css directory (optional). if provided, --font option is expected.').option('--font [path]', 'path to font directory (optional). if provided, --css option is expected.').option('--host [host]', 'address of fontello instance (optional).');
+  program.version(pjson.version).usage('[command] [options]').option('--config [path]', 'path to fontello config. defaults to ./config.json').option('--css [path]', 'path to css directory (optional). if provided, --font option is expected.').option('--font [path]', 'path to font directory (optional). if provided, --css option is expected.').option('--host [host]', 'address of fontello instance (optional).');
 
   program.command('install').description('download fontello. without --css and --font flags, the full download is extracted.').action(function(env, options) {
     if (program.css && program.font) {

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -22,7 +22,7 @@ config = 'config.json'
 program
   .version(pjson.version)
   .usage('[command] [options]')
-  .option('--config [path]', 'path to fontello config. defaults to ./config')
+  .option('--config [path]', 'path to fontello config. defaults to ./config.json')
   .option('--css [path]', 'path to css directory (optional). if provided, --font option is expected.')
   .option('--font [path]', 'path to font directory (optional). if provided, --css option is expected.')
   .option('--host [host]', 'address of fontello instance (optional).')


### PR DESCRIPTION
Hey! I tried installing a configuration using this package but it threw an error on me. The reason was that, and according to the help, I put my `config.json` in a `.config` folder, when in fact I should've just put the `config.json` at the root of the project and `fontello-cli install`.

I thought maybe you'd want to update your help. Thanks!
