### PR TITLE
Bump needle

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   },
   "dependencies": {
     "colors": "0.6.1",
-    "open": "0.0.4",
     "commander": "2.0.0",
-    "needle": "0.5.8",
     "mkdirp": "0.3.5",
+    "needle": "^0.10.0",
+    "open": "0.0.4",
     "unzip": "0.1.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Needle 0.5.8 didn't have pinned dependencies. A dependency of needle `qs` was updated to 6.0.0 and now can only be run in `--harmony` mode.

I updated needle to 0.10.0, where dependencies are pinned, and it seems like everything works.
