### PR TITLE
Follow keep alive requests on install

### DIFF
--- a/lib/fontello.js
+++ b/lib/fontello.js
@@ -52,7 +52,9 @@
     install: function(options) {
       return apiRequest(options, function(sessionUrl) {
         var requestOptions, zipFile;
-        requestOptions = {};
+        requestOptions = {
+          follow: 10
+        };
         if (options.proxy != null) {
           requestOptions.proxy = options.proxy;
         }


### PR DESCRIPTION
I believe this fixes #28.  I've been running `fontello-cli install` in a loop for about ten minutes without any failures.
