### PR TITLE
Use https for fontello host

### DIFF
--- a/lib/fontello.js
+++ b/lib/fontello.js
@@ -14,7 +14,7 @@
 
   unzip = require('unzipper');
 
-  HOST = 'http://fontello.com';
+  HOST = 'https://fontello.com';
 
   apiRequest = function(options, successCallback, errorCallback) {
     var data, requestOptions;

--- a/src/fontello.coffee
+++ b/src/fontello.coffee
@@ -6,7 +6,7 @@ process = require 'process'
 unzip = require 'unzipper'
 
 
-HOST = 'http://fontello.com'
+HOST = 'https://fontello.com'
 
 
 apiRequest = (options, successCallback, errorCallback) ->


### PR DESCRIPTION
This resolves #39, which causes fontello-cli fail silently.